### PR TITLE
Fix backwards incompatibility and support both py2 and py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
--   "3.4"
+-   "2.7"
 -   "3.5"
 install:
 -   pip install tox-travis

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/chrisglass/bpickle3.svg?branch=master)](https://travis-ci.org/chrisglass/bpickle3)
+[![Build Status](https://travis-ci.org/CanonicalLtd/bpickle3.svg?branch=master)](https://travis-ci.org/CanonicalLtd/bpickle3)
 
-bpickle3, a python3 serialization library
-=========================================
+bpickle3, a python2/3 serialization library
+===========================================

--- a/bpickle/__init__.py
+++ b/bpickle/__init__.py
@@ -192,6 +192,7 @@ if bytes == str:
     dumps_table.update({
         str: dumps_bytes,
         unicode: dumps_unicode,
+        long: dumps_int,
     })
 else:
     # Python 3.x: We need to map internal strings to bytestrings,

--- a/bpickle/__init__.py
+++ b/bpickle/__init__.py
@@ -74,7 +74,8 @@ def dumps_bytes(obj):
 
 
 def dumps_unicode(obj):
-    return b"u%d:%s" % (len(obj), obj.encode("utf-8"))
+    obj = obj.encode("utf-8")
+    return b"u%d:%s" % (len(obj), obj)
 
 
 def dumps_list(obj, _dt=dumps_table):
@@ -102,7 +103,7 @@ def dumps_none(obj):
 
 
 def loads_bool(bytestring, pos):
-    return bool(int(bytestring[pos+1])), pos+2
+    return bool(int(bytestring[pos+1:pos+2])), pos+2
 
 
 def loads_int(bytestring, pos):
@@ -131,8 +132,8 @@ def loads_list(bytestring, pos, _lt=loads_table):
     pos += 1
     res = []
     append = res.append
-    while bytestring[pos] != b";":
-        obj, pos = _lt[bytestring[pos]](bytestring, pos)
+    while bytestring[pos:pos+1] != b";":
+        obj, pos = _lt[bytestring[pos:pos+1]](bytestring, pos)
         append(obj)
     return res, pos+1
 
@@ -141,8 +142,8 @@ def loads_tuple(bytestring, pos, _lt=loads_table):
     pos += 1
     res = []
     append = res.append
-    while bytestring[pos] != b";":
-        obj, pos = _lt[bytestring[pos]](bytestring, pos)
+    while bytestring[pos:pos+1] != b";":
+        obj, pos = _lt[bytestring[pos:pos+1]](bytestring, pos)
         append(obj)
     return tuple(res), pos+1
 
@@ -150,9 +151,9 @@ def loads_tuple(bytestring, pos, _lt=loads_table):
 def loads_dict(bytestring, pos, _lt=loads_table):
     pos += 1
     res = {}
-    while bytestring[pos] != b";":
-        key, pos = _lt[bytestring[pos]](bytestring, pos)
-        val, pos = _lt[bytestring[pos]](bytestring, pos)
+    while bytestring[pos:pos+1] != b";":
+        key, pos = _lt[bytestring[pos:pos+1]](bytestring, pos)
+        val, pos = _lt[bytestring[pos:pos+1]](bytestring, pos)
         res[key] = val
     return res, pos+1
 

--- a/bpickle/__init__.py
+++ b/bpickle/__init__.py
@@ -52,8 +52,7 @@ def loads(byte_string, _lt=loads_table):
         return _lt[unicode_string[0]](unicode_string, 0)[0]
     except KeyError as e:
         raise ValueError("Unknown type character: %s" % e)
-    except IndexError:  #pragma: nocover
-        # NOTE: Not sure if reachable (chrisglass during py3 conversion)
+    except IndexError:
         raise ValueError("Corrupted data")
 
 

--- a/bpickle/__init__.py
+++ b/bpickle/__init__.py
@@ -39,7 +39,7 @@ loads_table = {}
 
 def dumps(obj, _dt=dumps_table):
     try:
-        return _dt[type(obj)](obj).encode("UTF-8")
+        return _dt[type(obj)](obj)
     except KeyError as e:
         raise ValueError("Unsupported type: %s" % e)
 
@@ -47,9 +47,10 @@ def dumps(obj, _dt=dumps_table):
 def loads(byte_string, _lt=loads_table):
     if not byte_string:
         raise ValueError("Can't load empty string")
-    unicode_string = byte_string.decode()
     try:
-        return _lt[unicode_string[0]](unicode_string, 0)[0]
+        # To avoid python3 turning byte_string[0] into an int,
+        # we slice the bytestring instead.
+        return _lt[byte_string[0:1]](byte_string, 0)[0]
     except KeyError as e:
         raise ValueError("Unknown type character: %s" % e)
     except IndexError:
@@ -57,27 +58,31 @@ def loads(byte_string, _lt=loads_table):
 
 
 def dumps_bool(obj):
-    return "b%d" % int(obj)
+    return b"b%d" % int(obj)
 
 
 def dumps_int(obj):
-    return "i%s;" % obj
+    return b"i%d;" % obj
 
 
 def dumps_float(obj):
-    return "f%r;" % obj
+    return b"f%r;" % obj
 
 
-def dumps_str(obj):
-    return "s%s:%s" % (len(obj), obj)
+def dumps_bytes(obj):
+    return b"s%d:%s" % (len(obj), obj)
+
+
+def dumps_unicode(obj):
+    return b"u%d:%s" % (len(obj), obj.encode("utf-8"))
 
 
 def dumps_list(obj, _dt=dumps_table):
-    return "l%s;" % "".join([_dt[type(val)](val) for val in obj])
+    return b"l%s;" % b"".join([_dt[type(val)](val) for val in obj])
 
 
 def dumps_tuple(obj, _dt=dumps_table):
-    return "t%s;" % "".join([_dt[type(val)](val) for val in obj])
+    return b"t%s;" % b"".join([_dt[type(val)](val) for val in obj])
 
 
 def dumps_dict(obj, _dt=dumps_table):
@@ -89,59 +94,65 @@ def dumps_dict(obj, _dt=dumps_table):
         val = obj[key]
         append(_dt[type(key)](key))
         append(_dt[type(val)](val))
-    return "d%s;" % "".join(res)
+    return b"d%s;" % b"".join(res)
 
 
 def dumps_none(obj):
-    return "n"
+    return b"n"
 
 
-def loads_bool(str, pos):
-    return bool(int(str[pos+1])), pos+2
+def loads_bool(bytestring, pos):
+    return bool(int(bytestring[pos+1])), pos+2
 
 
-def loads_int(str, pos):
-    endpos = str.index(";", pos)
-    return int(str[pos+1:endpos]), endpos+1
+def loads_int(bytestring, pos):
+    endpos = bytestring.index(b";", pos)
+    return int(bytestring[pos+1:endpos]), endpos+1
 
 
-def loads_float(str, pos):
-    endpos = str.index(";", pos)
-    return float(str[pos+1:endpos]), endpos+1
+def loads_float(bytestring, pos):
+    endpos = bytestring.index(b";", pos)
+    return float(bytestring[pos+1:endpos]), endpos+1
 
 
-def loads_str(str, pos):
-    startpos = str.index(":", pos)+1
-    endpos = startpos+int(str[pos+1:startpos-1])
-    return str[startpos:endpos], endpos
+def loads_bytes(bytestring, pos):
+    startpos = bytestring.index(b":", pos)+1
+    endpos = startpos+int(bytestring[pos+1:startpos-1])
+    return bytestring[startpos:endpos], endpos
 
 
-def loads_list(str, pos, _lt=loads_table):
+def loads_unicode(bytestring, pos):
+    startpos = bytestring.index(b":", pos)+1
+    endpos = startpos+int(bytestring[pos+1:startpos-1])
+    return bytestring[startpos:endpos].decode("utf-8"), endpos
+
+
+def loads_list(bytestring, pos, _lt=loads_table):
     pos += 1
     res = []
     append = res.append
-    while str[pos] != ";":
-        obj, pos = _lt[str[pos]](str, pos)
+    while bytestring[pos] != b";":
+        obj, pos = _lt[bytestring[pos]](bytestring, pos)
         append(obj)
     return res, pos+1
 
 
-def loads_tuple(str, pos, _lt=loads_table):
+def loads_tuple(bytestring, pos, _lt=loads_table):
     pos += 1
     res = []
     append = res.append
-    while str[pos] != ";":
-        obj, pos = _lt[str[pos]](str, pos)
+    while bytestring[pos] != b";":
+        obj, pos = _lt[bytestring[pos]](bytestring, pos)
         append(obj)
     return tuple(res), pos+1
 
 
-def loads_dict(str, pos, _lt=loads_table):
+def loads_dict(bytestring, pos, _lt=loads_table):
     pos += 1
     res = {}
-    while str[pos] != ";":
-        key, pos = _lt[str[pos]](str, pos)
-        val, pos = _lt[str[pos]](str, pos)
+    while bytestring[pos] != b";":
+        key, pos = _lt[bytestring[pos]](bytestring, pos)
+        val, pos = _lt[bytestring[pos]](bytestring, pos)
         res[key] = val
     return res, pos+1
 
@@ -150,22 +161,42 @@ def loads_none(str, pos):
     return None, pos+1
 
 
-dumps_table.update({       bool: dumps_bool,
-                            int: dumps_int,
-                          float: dumps_float,
-                            str: dumps_str,
-                           list: dumps_list,
-                          tuple: dumps_tuple,
-                           dict: dumps_dict,
-                     type(None): dumps_none     })
+dumps_table.update({
+    bool: dumps_bool,
+    int: dumps_int,
+    float: dumps_float,
+    list: dumps_list,
+    tuple: dumps_tuple,
+    dict: dumps_dict,
+    type(None): dumps_none
+})
 
-loads_table.update({ "b": loads_bool,
-                     "i": loads_int,
-                     "f": loads_float,
-                     "s": loads_str,
-                     "u": loads_str,
-                     "l": loads_list,
-                     "t": loads_tuple,
-                     "d": loads_dict,
-                     "n": loads_none     })
+
+loads_table.update({
+    b"b": loads_bool,
+    b"i": loads_int,
+    b"f": loads_float,
+    b"l": loads_list,
+    b"t": loads_tuple,
+    b"d": loads_dict,
+    b"n": loads_none,
+    b"s": loads_bytes,
+    b"u": loads_unicode,
+})
+
+
+if bytes == str:
+    # Python 2.x: We need to map internal strings to bytestrings,
+    # and internal unicode strings to UTF-8 encoded strings.
+    dumps_table.update({
+        str: dumps_bytes,
+        unicode: dumps_unicode,
+    })
+else:
+    # Python 3.x: We need to map internal strings to bytestrings,
+    # and internal unicode strings to UTF-8 encoded strings.
+    dumps_table.update({
+        str: dumps_unicode,
+        bytes: dumps_bytes,
+    })
 

--- a/bpickle/tests/test_bpickle.py
+++ b/bpickle/tests/test_bpickle.py
@@ -78,6 +78,16 @@ class BPickleTest(unittest.TestCase):
         wrong = b'zblah'  # 'z' is not a valid type character.
         self.assertRaises(ValueError, bpickle.loads, wrong)
 
+    def test_loads_broken_data(self):
+        """
+        If loads table somehow ends up using load function that does not
+        return a tuple of value and position, ValueError is thrown.
+        """
+        loads_table = {"s": lambda self, obj: []}
+        with self.assertRaises(ValueError) as context:
+            bpickle.loads(b"s3:foo", loads_table)
+        self.assertEqual("Corrupted data", str(context.exception))
+
     def test_ping_result_message_decode(self):
         """
         This is an example message received from an actual ping server. Let's

--- a/bpickle/tests/test_bpickle.py
+++ b/bpickle/tests/test_bpickle.py
@@ -83,7 +83,7 @@ class BPickleTest(unittest.TestCase):
         If loads table somehow ends up using load function that does not
         return a tuple of value and position, ValueError is thrown.
         """
-        loads_table = {"s": lambda self, obj: []}
+        loads_table = {b"s": lambda self, obj: []}
         with self.assertRaises(ValueError) as context:
             bpickle.loads(b"s3:foo", loads_table)
         self.assertEqual("Corrupted data", str(context.exception))

--- a/bpickle/tests/test_bpickle.py
+++ b/bpickle/tests/test_bpickle.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 from hypothesis import given
 from hypothesis.strategies import (
@@ -8,10 +9,6 @@ from hypothesis.strategies import (
 
 
 import bpickle
-
-REAL_ANSWER = (b"ds8:messageslds4:types14:accepted-typess5:typeslu8:register"
-               b"u4:test;;ds2:ids9:secure-ids11:insecure-idi999999;s4:types6:"
-               b"set-id;;s10:server-apiu3:3.3s11:server-uuids11:server-uuid;")
 
 
 class BPickleTest(unittest.TestCase):
@@ -30,34 +27,40 @@ class BPickleTest(unittest.TestCase):
 
     @given(text())
     def test_string(self, s):
-        assert bpickle.loads(bpickle.dumps('foo')) == 'foo'
+        assert bpickle.loads(bpickle.dumps(b'foo')) == b'foo'
 
     def test_list(self):
-        self.assertEqual(bpickle.loads(bpickle.dumps([1, 2, 'hello', 3.0])),
-                         [1, 2, 'hello', 3.0])
+        self.assertEqual(
+            bpickle.loads(bpickle.dumps([1, 2, u'hello', b'world', 3.0])),
+            [1, 2, u'hello', b'world', 3.0])
 
     @given(lists(integers()))
     def test_inverted_lists(self, l):
         assert bpickle.loads(bpickle.dumps(l)) == l
 
     def test_tuple(self):
-        data = bpickle.dumps((1, [], 2, 'hello', 3.0))
+        data = bpickle.dumps((1, [], 2, u'hello', b'world', 3.0))
         self.assertEqual(bpickle.loads(data),
-                         (1, [], 2, 'hello', 3.0))
+                         (1, [], 2, u'hello', b'world', 3.0))
 
     def test_none(self):
         self.assertEqual(bpickle.loads(bpickle.dumps(None)), None)
 
     def test_unicode(self):
-        self.assertEqual(bpickle.loads(bpickle.dumps(u'\xc0')), u'\xc0')
+        dumped_unicode = bpickle.dumps(u'\N{SNOWMAN}')
+        loaded_unicode = bpickle.loads(dumped_unicode)
+        self.assertEqual(u'☃', loaded_unicode)
 
     def test_bool(self):
         self.assertEqual(bpickle.loads(bpickle.dumps(True)), True)
 
+    def test_bool_false(self):
+        self.assertEqual(bpickle.loads(bpickle.dumps(False)), False)
+
     def test_dict(self):
-        dumped_tostr = bpickle.dumps({True: "hello"})
+        dumped_tostr = bpickle.dumps({True: u"hello"})
         self.assertEqual(bpickle.loads(dumped_tostr),
-                         {True: "hello"})
+                         {True: u"hello"})
         dumped_tobool = bpickle.dumps({True: False})
         self.assertEqual(bpickle.loads(dumped_tobool),
                          {True: False})
@@ -67,7 +70,7 @@ class BPickleTest(unittest.TestCase):
         self.assertEqual(bpickle.loads(bpickle.dumps(long)), long)
 
     def test_loads_empty_string(self):
-        self.assertRaises(ValueError, bpickle.loads, "")
+        self.assertRaises(ValueError, bpickle.loads, b"")
 
     def test_dumps_unsupported_object(self):
         class something(object):
@@ -95,24 +98,30 @@ class BPickleTest(unittest.TestCase):
         """
         repsonse = b'ds8:messagesb1;'  # As returned by the "requests" lib
         result = bpickle.loads(repsonse)
-        expected = {"messages": True}
+        expected = {b"messages": True}
         self.assertEqual(expected, result)
 
     def test_ping_result_message_encode(self):
         """Let's ensure the encoding/decoding is symmetric "by hand"."""
-        payload = {"messages": True}
+        payload = {b"messages": True}
         expected = b'ds8:messagesb1;'
         result = bpickle.dumps(payload)
         self.assertEqual(expected, result)
 
     def test_real_registration_answer_loading(self):
         """ We succeed at decoding a real-world example."""
+        REAL_ANSWER = (
+            b"ds8:messageslds4:types14:accepted-typess5:typeslu8:register"
+            b"u4:test;;ds2:ids9:secure-ids11:insecure-idi999999;s4:types6:"
+            b"set-id;;s10:server-apiu3:3.3s11:server-uuids11:server-uuid;")
+
         expected = {
-            'server-api': '3.3',
-            'server-uuid': 'server-uuid',
-            'messages': [
-                {'types': ['register', 'test'], 'type': 'accepted-types'},
-                {'id': 'secure-id', 'insecure-id': 999999, 'type': 'set-id'}]}
+            b'server-api': u'3.3',
+            b'server-uuid': b'server-uuid',
+            b'messages': [
+                {b'types': [u'register', u'test'], b'type': b'accepted-types'},
+                {b'id': b'secure-id', b'insecure-id': 999999,
+                 b'type': b'set-id'}]}
 
         result = bpickle.loads(REAL_ANSWER)
         self.assertEqual(expected, result)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py34
+envlist = py35, py27
 [testenv]
 install_command=                                                                                                                                                                                                    
     pip install --process-dependency-links {opts} {packages}


### PR DESCRIPTION
Split off unicode handling from byte string handling to ensure it works correctly for either type of the string.

As a caveat, in python3, bytestring[pos] returns an integer, so to get a single-character bytestring I do bytestring[pos:pos+1] in a number of places.

(I've also added a test for that hard-to-reach IndexError case in loads() and a few other drive-by cleanups)